### PR TITLE
Release 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ output "serverless-user-access-key-id" {
   value = module.serverless-user.aws_access_key_id
 }
 output "serverless-user-secret-access-key" {
-  value = module.serverless-user.aws_secret_access_key
+  value     = module.serverless-user.aws_secret_access_key
+  sensitive = true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ if needed as well.
 ## Optional Inputs 
  - `extra_policies`     - Optionally provide additional inline policies to attach to user. Default: `[]`
  - `policy_override`    - Optionally provide a json policy to use instead of default. Default: `""`
- - `username`           - Optionally provide a username for the serverless user. It defaults to `app_name-app_env-serverless`
+ - `username`           - Optionally provide a username for the serverless user. It defaults to `app_name-serverless`
  - `enable_api_gateway` - Optionally enable API Gateway related permissions. 
                           Needed for lambda functions that will be accessed via URL endpoints. Default: `false` 
 
@@ -27,7 +27,7 @@ if needed as well.
 ```hcl
 module "serverless-user" {
   source = "silinternational/serverless-user/aws"
-  version = "0.6.0"
+  version = "0.1.0"
   
   app_name = "serverless-user"
   aws_region = "us-east-1"

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,6 @@
+module "serverless-user" {
+  source = "../"
+
+  app_name   = "serverless-user"
+  aws_region = var.aws_region
+}

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -1,0 +1,8 @@
+output "serverless-user-access-key-id" {
+  value = module.serverless-user.aws_access_key_id
+}
+
+output "serverless-user-secret-access-key" {
+  value     = module.serverless-user.aws_secret_access_key
+  sensitive = true
+}

--- a/example/providers.tf
+++ b/example/providers.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 3.37"
+}

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,3 @@
+variable "aws_region" {
+  default = "us-east-1"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,7 @@ output "aws_access_key_id" {
   value = aws_iam_access_key.serverless.id
 }
 output "aws_secret_access_key" {
-  value = aws_iam_access_key.serverless.secret
+  value     = aws_iam_access_key.serverless.secret
   sensitive = true
 }
 output "serverless_user_username" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,7 @@ output "aws_access_key_id" {
 }
 output "aws_secret_access_key" {
   value = aws_iam_access_key.serverless.secret
+  sensitive = true
 }
 output "serverless_user_username" {
   value = aws_iam_user.serverless.name

--- a/serverless-iam-policy.json
+++ b/serverless-iam-policy.json
@@ -19,7 +19,11 @@
         "cloudformation:CreateUploadBucket",
         "cloudformation:DeleteStack",
         "cloudformation:Describe*",
-        "cloudformation:UpdateStack"
+        "cloudformation:UpdateStack",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:DeleteChangeSet",
+        "cloudformation:CreateChangeSet",
+        "cloudformation:ExecuteChangeSet"
       ],
       "Resource": [
         "arn:aws:cloudformation:${aws_region}:*:stack/${app_name}*/*"

--- a/vars.tf
+++ b/vars.tf
@@ -27,6 +27,6 @@ variable "policy_override" {
 
 variable "username" {
   type        = string
-  description = "Optionally provide a username for the serverless user. It defaults to app_name-app_env-serverless"
+  description = "Optionally provide a username for the serverless user. It defaults to app_name-serverless"
   default     = ""
 }


### PR DESCRIPTION
## Added
- Added working example files that can be used for `terraform validate`.
- Added additional actions to support Serverless v3
## Fixed
- Corrected minor documentation errors
- Removed dependency on archived "template" provider
- Added sensitive to AWS access key output