### PR TITLE
Release 0.1.2 - added lambda tags permissions

### DIFF
--- a/serverless-iam-policy.json
+++ b/serverless-iam-policy.json
@@ -71,6 +71,8 @@
         "lambda:InvokeFunction",
         "lambda:PublishVersion",
         "lambda:RemovePermission",
+        "lambda:TagResource",
+        "lambda:UntagResource",
         "lambda:Update*",
         "lambda:PutFunctionEventInvokeConfig",
         "lambda:DeleteFunctionEventInvokeConfig"


### PR DESCRIPTION
### Fix
- Add permissions needed for lambda tags: `lambda:TagResource` and `lambda:UntagResource`. Fixes #11 