### PR TITLE
Fix IAM policy to also work for role without a region in its name

### DIFF
--- a/serverless-iam-policy.json
+++ b/serverless-iam-policy.json
@@ -95,6 +95,7 @@
         "iam:PassRole"
       ],
       "Resource": [
+        "arn:aws:iam::*:role/${app_name}*-lambdaRole",
         "arn:aws:iam::*:role/${app_name}*-${aws_region}-lambdaRole"
       ]
     },


### PR DESCRIPTION
### Fixed
- Fix IAM policy to also work for role without a region in its name