### PR TITLE
Release 0.4.0 -- update aws provider to allow version 5

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,7 +7,7 @@ name: 'Terraform'
 
 on:
   push:
-    branches: [*]
+    branches: ["*"]
 
 permissions:
   contents: read

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,7 +7,7 @@ name: 'Terraform'
 
 on:
   push:
-  pull_request:
+    branches: [*]
 
 permissions:
   contents: read
@@ -25,11 +25,11 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Install the latest version of Terraform CLI
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
 
     # Checks that all Terraform configuration files adhere to a canonical format
     - name: Terraform Format

--- a/test/main.tf
+++ b/test/main.tf
@@ -29,7 +29,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      version = "~ 5.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/test/main.tf
+++ b/test/main.tf
@@ -22,14 +22,15 @@ provider "aws" {
 }
 
 locals {
-  aws_region = "us-east1"
+  aws_region = "us-east-1"
 }
 
 terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = "~ 4.0"
+      source  = "hashicorp/aws"
     }
   }
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -29,7 +29,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      version = "~ 4.0"
+      version = "~ 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 2.0.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
### Changed
- Update aws provider version constraints to allow version 5
- Update GitHub Actions checkout and setup-terraform actions

### Fixed
- Fixed region used in test