### PR TITLE
Release 0.4.1 -- remove aws_region variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This module is published in [Terraform Registry](https://registry.terraform.io/m
 
 ## Required Inputs
  - `app_name`   - A short name for this application, example: `backup-service`. Must be 24 characters or less, including the stage name and a hyphen. If only one stage is used, the app_name can use the entire 24 characters."
- - `aws_region` - A valid AWS region where this lambda will be deployed, example: `us-east-1`
 
 ## Optional Inputs 
  - `aws_region_policy`  - The region to use in creating the IAM policy document. Use "*" to allowing deployment to all regions. Default: `"us-east-1"`
@@ -33,7 +32,6 @@ module "serverless-user" {
   version = "0.1.0"
   
   app_name = "serverless-user"
-  aws_region = "us-east-1"
 }
 
 output "serverless-user-access-key-id" {

--- a/example/main.tf
+++ b/example/main.tf
@@ -2,8 +2,7 @@ module "serverless-user" {
   source  = "silinternational/serverless-user/aws"
   version = ">= 0.1.3"
 
-  app_name   = "serverless-user"
-  aws_region = var.aws_region
+  app_name = "serverless-user"
 
   username = "app_serverless_username"
   extra_policies = jsonencode([

--- a/test/main.tf
+++ b/test/main.tf
@@ -16,11 +16,7 @@ module "all" {
 }
 
 provider "aws" {
-  region = local.aws_region
-}
-
-locals {
-  aws_region = "us-east-1"
+  region = "us-east-1"
 }
 
 terraform {

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,15 +1,13 @@
 module "minimal" {
   source = "../"
 
-  app_name   = "test"
-  aws_region = local.aws_region
+  app_name = "test"
 }
 
 module "all" {
   source = "../"
 
   app_name           = "test"
-  aws_region         = local.aws_region
   aws_region_policy  = "*"
   enable_api_gateway = true
   extra_policies     = ["extra_policies"]

--- a/vars.tf
+++ b/vars.tf
@@ -3,11 +3,6 @@ variable "app_name" {
   description = "A short name for this application, example: backup-service. Must be 24 characters or less, including the stage name and a hyphen."
 }
 
-variable "aws_region" {
-  type        = string
-  description = "A valid AWS region where this lambda will be deployed"
-}
-
 variable "aws_region_policy" {
   description = "The region to use in creating the IAM policy document. Use \"*\" to allowing deployment to all regions."
   default     = "us-east-1"


### PR DESCRIPTION
### Removed
- Removed `aws_region` variable. The AWS region is and always has been specified by the `aws_region` parameter in the aws provider block at the root level.